### PR TITLE
Added meta information to each site

### DIFF
--- a/build/build.js
+++ b/build/build.js
@@ -156,6 +156,38 @@ var readFile = function( srcFilePath, next ) {
 var buildFile = function( fileExtension, data, fileContent, next ) {
 	hbs.cwd = path.dirname( data.targetFilePath );
 	hbs.outputDir = data.outputDir;
+	// defaults
+	data.contextVars.title = 'A Scalable Server for Realtime Web Apps';
+	data.contextVars.description = 'a node.js realtime server';
+	if( fileExtension === 'md' ) {
+		var metaDataEnd = fileContent.indexOf( '}' ),
+			metaData;
+
+		if( metaDataEnd === -1 ) {
+			throw new Error( 'Missing meta-data section for ' + data.targetFilePath );
+		}
+
+		try{
+			metaData = JSON.parse( fileContent.substr( 0, metaDataEnd + 1 ) );
+		} catch( e ) {
+			console.log( fileContent.substr( 0, metaDataEnd + 1 ) );
+			console.log( e );
+			throw new Error( 'Can\'t parse meta-data for ' + data.targetFilePath );
+		}
+
+		if( !metaData.title ) {
+			throw new Error( 'Missing title for ' + data.targetFilePath );
+		}
+
+		if( !metaData.description ) {
+			throw new Error( 'Missing description for ' + data.targetFilePath );
+		}
+
+		data.contextVars.title = metaData.title;
+		data.contextVars.description = metaData.description;
+		fileContent = fileContent.substr( metaDataEnd + 1 ).trim();
+	}
+
 
 	fileBuilder[ fileExtension ].build( fileContent, data, function( error, innerHtml ){
 		if( data.contextVars.hasNav ) {

--- a/htdocs/docs/anonymous_record.html
+++ b/htdocs/docs/anonymous_record.html
@@ -2,11 +2,11 @@
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<title>deepstream.io | A Scalable Server for Realtime Web Apps</title>
+	<title>deepstream.io | anonymous record documentation</title>
 
 	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 	<meta name="keywords" content="deepstream, deepstream.io, streaming, realtime, server, socket" />
-	<meta name="description" content="deepstream.io - a scalable server for realtime web apps" />
+	<meta name="description" content="learn how to use anonymous records to switch context without having to renew bindings" />
 	<meta name="author" content="Wolfram Hempel" />
 	<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
 	<link rel="icon" href="/favicon.ico" type="image/x-icon">

--- a/htdocs/docs/client.event.html
+++ b/htdocs/docs/client.event.html
@@ -2,11 +2,11 @@
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<title>deepstream.io | A Scalable Server for Realtime Web Apps</title>
+	<title>deepstream.io | event API documentation</title>
 
 	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 	<meta name="keywords" content="deepstream, deepstream.io, streaming, realtime, server, socket" />
-	<meta name="description" content="deepstream.io - a scalable server for realtime web apps" />
+	<meta name="description" content="understand events, deepstream&#x27;s many to many broadcasting mechanism" />
 	<meta name="author" content="Wolfram Hempel" />
 	<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
 	<link rel="icon" href="/favicon.ico" type="image/x-icon">

--- a/htdocs/docs/client.html
+++ b/htdocs/docs/client.html
@@ -2,11 +2,11 @@
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<title>deepstream.io | A Scalable Server for Realtime Web Apps</title>
+	<title>deepstream.io | javascript client API documentation</title>
 
 	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 	<meta name="keywords" content="deepstream, deepstream.io, streaming, realtime, server, socket" />
-	<meta name="description" content="deepstream.io - a scalable server for realtime web apps" />
+	<meta name="description" content="the API docs for the deepstream javascript client" />
 	<meta name="author" content="Wolfram Hempel" />
 	<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
 	<link rel="icon" href="/favicon.ico" type="image/x-icon">

--- a/htdocs/docs/client.record.html
+++ b/htdocs/docs/client.record.html
@@ -2,11 +2,11 @@
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<title>deepstream.io | A Scalable Server for Realtime Web Apps</title>
+	<title>deepstream.io | Record API documentation</title>
 
 	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 	<meta name="keywords" content="deepstream, deepstream.io, streaming, realtime, server, socket" />
-	<meta name="description" content="deepstream.io - a scalable server for realtime web apps" />
+	<meta name="description" content="the API docs for deepstream records" />
 	<meta name="author" content="Wolfram Hempel" />
 	<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
 	<link rel="icon" href="/favicon.ico" type="image/x-icon">

--- a/htdocs/docs/client.rpc.html
+++ b/htdocs/docs/client.rpc.html
@@ -2,11 +2,11 @@
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<title>deepstream.io | A Scalable Server for Realtime Web Apps</title>
+	<title>deepstream.io | RPC API documentation</title>
 
 	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 	<meta name="keywords" content="deepstream, deepstream.io, streaming, realtime, server, socket" />
-	<meta name="description" content="deepstream.io - a scalable server for realtime web apps" />
+	<meta name="description" content="the API docs for Remote Procedure Calls, deepstream&#x27;s request-response mechanism" />
 	<meta name="author" content="Wolfram Hempel" />
 	<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
 	<link rel="icon" href="/favicon.ico" type="image/x-icon">

--- a/htdocs/docs/client_errors.html
+++ b/htdocs/docs/client_errors.html
@@ -2,11 +2,11 @@
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<title>deepstream.io | A Scalable Server for Realtime Web Apps</title>
+	<title>deepstream.io | runtime error documentation</title>
 
 	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 	<meta name="keywords" content="deepstream, deepstream.io, streaming, realtime, server, socket" />
-	<meta name="description" content="deepstream.io - a scalable server for realtime web apps" />
+	<meta name="description" content="the API docs for deepstream&#x27;s runtime errors" />
 	<meta name="author" content="Wolfram Hempel" />
 	<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
 	<link rel="icon" href="/favicon.ico" type="image/x-icon">

--- a/htdocs/docs/client_options.html
+++ b/htdocs/docs/client_options.html
@@ -2,11 +2,11 @@
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<title>deepstream.io | A Scalable Server for Realtime Web Apps</title>
+	<title>deepstream.io | client options</title>
 
 	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 	<meta name="keywords" content="deepstream, deepstream.io, streaming, realtime, server, socket" />
-	<meta name="description" content="deepstream.io - a scalable server for realtime web apps" />
+	<meta name="description" content="the options that the deepstream javascript client can be initialized with" />
 	<meta name="author" content="Wolfram Hempel" />
 	<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
 	<link rel="icon" href="/favicon.ico" type="image/x-icon">

--- a/htdocs/docs/connection_states.html
+++ b/htdocs/docs/connection_states.html
@@ -2,11 +2,11 @@
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<title>deepstream.io | A Scalable Server for Realtime Web Apps</title>
+	<title>deepstream.io | connection state documentation</title>
 
 	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 	<meta name="keywords" content="deepstream, deepstream.io, streaming, realtime, server, socket" />
-	<meta name="description" content="deepstream.io - a scalable server for realtime web apps" />
+	<meta name="description" content="a list of all possible connection states" />
 	<meta name="author" content="Wolfram Hempel" />
 	<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
 	<link rel="icon" href="/favicon.ico" type="image/x-icon">
@@ -158,7 +158,6 @@
 </tr>
 
 </table>
-
 
 			</div>
 		</div>

--- a/htdocs/docs/constants.html
+++ b/htdocs/docs/constants.html
@@ -2,11 +2,11 @@
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<title>deepstream.io | A Scalable Server for Realtime Web Apps</title>
+	<title>deepstream.io | constants documentation</title>
 
 	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 	<meta name="keywords" content="deepstream, deepstream.io, streaming, realtime, server, socket" />
-	<meta name="description" content="deepstream.io - a scalable server for realtime web apps" />
+	<meta name="description" content="a list of all constants deepstream uses" />
 	<meta name="author" content="Wolfram Hempel" />
 	<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
 	<link rel="icon" href="/favicon.ico" type="image/x-icon">

--- a/htdocs/docs/deepstream.html
+++ b/htdocs/docs/deepstream.html
@@ -2,11 +2,11 @@
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<title>deepstream.io | A Scalable Server for Realtime Web Apps</title>
+	<title>deepstream.io | deepstream server documentation</title>
 
 	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 	<meta name="keywords" content="deepstream, deepstream.io, streaming, realtime, server, socket" />
-	<meta name="description" content="deepstream.io - a scalable server for realtime web apps" />
+	<meta name="description" content="API docs for new Deepstream();" />
 	<meta name="author" content="Wolfram Hempel" />
 	<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
 	<link rel="icon" href="/favicon.ico" type="image/x-icon">

--- a/htdocs/docs/event_emitter.html
+++ b/htdocs/docs/event_emitter.html
@@ -2,11 +2,11 @@
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<title>deepstream.io | A Scalable Server for Realtime Web Apps</title>
+	<title>deepstream.io | EventEmitter documentation</title>
 
 	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 	<meta name="keywords" content="deepstream, deepstream.io, streaming, realtime, server, socket" />
-	<meta name="description" content="deepstream.io - a scalable server for realtime web apps" />
+	<meta name="description" content="API docs for deepstream&#x27;s event emitter" />
 	<meta name="author" content="Wolfram Hempel" />
 	<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
 	<link rel="icon" href="/favicon.ico" type="image/x-icon">

--- a/htdocs/docs/index.html
+++ b/htdocs/docs/index.html
@@ -6,7 +6,7 @@
 
 	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 	<meta name="keywords" content="deepstream, deepstream.io, streaming, realtime, server, socket" />
-	<meta name="description" content="deepstream.io - a scalable server for realtime web apps" />
+	<meta name="description" content="a node.js realtime server" />
 	<meta name="author" content="Wolfram Hempel" />
 	<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
 	<link rel="icon" href="/favicon.ico" type="image/x-icon">

--- a/htdocs/docs/list.html
+++ b/htdocs/docs/list.html
@@ -2,11 +2,11 @@
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<title>deepstream.io | A Scalable Server for Realtime Web Apps</title>
+	<title>deepstream.io | List API documentation</title>
 
 	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 	<meta name="keywords" content="deepstream, deepstream.io, streaming, realtime, server, socket" />
-	<meta name="description" content="deepstream.io - a scalable server for realtime web apps" />
+	<meta name="description" content="API docs for deepstream&#x27;s list object, a manageable collection of record names" />
 	<meta name="author" content="Wolfram Hempel" />
 	<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
 	<link rel="icon" href="/favicon.ico" type="image/x-icon">

--- a/htdocs/docs/record.html
+++ b/htdocs/docs/record.html
@@ -2,11 +2,11 @@
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<title>deepstream.io | A Scalable Server for Realtime Web Apps</title>
+	<title>deepstream.io | record API documentation</title>
 
 	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 	<meta name="keywords" content="deepstream, deepstream.io, streaming, realtime, server, socket" />
-	<meta name="description" content="deepstream.io - a scalable server for realtime web apps" />
+	<meta name="description" content="the API docs for deepstream Records" />
 	<meta name="author" content="Wolfram Hempel" />
 	<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
 	<link rel="icon" href="/favicon.ico" type="image/x-icon">

--- a/htdocs/docs/rpc_response.html
+++ b/htdocs/docs/rpc_response.html
@@ -2,11 +2,11 @@
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<title>deepstream.io | A Scalable Server for Realtime Web Apps</title>
+	<title>deepstream.io | RPC response documentation</title>
 
 	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 	<meta name="keywords" content="deepstream, deepstream.io, streaming, realtime, server, socket" />
-	<meta name="description" content="deepstream.io - a scalable server for realtime web apps" />
+	<meta name="description" content="API docs for deepstream&#x27;s RPC response object" />
 	<meta name="author" content="Wolfram Hempel" />
 	<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
 	<link rel="icon" href="/favicon.ico" type="image/x-icon">

--- a/htdocs/download/index.html
+++ b/htdocs/download/index.html
@@ -6,7 +6,7 @@
 
 	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 	<meta name="keywords" content="deepstream, deepstream.io, streaming, realtime, server, socket" />
-	<meta name="description" content="deepstream.io - a scalable server for realtime web apps" />
+	<meta name="description" content="a node.js realtime server" />
 	<meta name="author" content="Wolfram Hempel" />
 	<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
 	<link rel="icon" href="/favicon.ico" type="image/x-icon">

--- a/htdocs/index.html
+++ b/htdocs/index.html
@@ -6,7 +6,7 @@
 
 	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 	<meta name="keywords" content="deepstream, deepstream.io, streaming, realtime, server, socket" />
-	<meta name="description" content="deepstream.io - a scalable server for realtime web apps" />
+	<meta name="description" content="a node.js realtime server" />
 	<meta name="author" content="Wolfram Hempel" />
 	<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
 	<link rel="icon" href="/favicon.ico" type="image/x-icon">

--- a/htdocs/info/client-release-notes.html
+++ b/htdocs/info/client-release-notes.html
@@ -2,11 +2,11 @@
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<title>deepstream.io | A Scalable Server for Realtime Web Apps</title>
+	<title>deepstream.io | Client release notes</title>
 
 	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 	<meta name="keywords" content="deepstream, deepstream.io, streaming, realtime, server, socket" />
-	<meta name="description" content="a node.js realtime server" />
+	<meta name="description" content="See what was released in every version of the deepstream javascript client" />
 	<meta name="author" content="Wolfram Hempel" />
 	<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
 	<link rel="icon" href="/favicon.ico" type="image/x-icon">
@@ -25,7 +25,7 @@
 	<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
 
 </head>
-<body class="category_tutorials">
+<body class="category_info">
 
 	<div id="outerWrapper">
 		<div class="topSection">
@@ -36,101 +36,27 @@
 				<ul>
 					<li ><a href="..">Home</a></li>
 					<li ><a href="../download/">Downloads</a></li>
-					<li class="active"><a href="../tutorials/getting-started.html">Tutorials</a></li>
+					<li ><a href="../tutorials/getting-started.html">Tutorials</a></li>
 					<li ><a href="../docs/deepstream.html">Documentation</a></li>
-					<li ><a href="../info/">Info</a></li>
+					<li class="active"><a href="../info/">Info</a></li>
 				</ul>
 			</div>
 		</div>
 		<div id="wrapper" class="main">
 			<ul id="subnav">
-	<li class="head first">General</li>
+	<li class="head first">Performance</li>
 	<li >
-		<a href="getting-started.html">Getting started</a>
+		<a href="performance-overview.html">Overview</a>
 		<div class="isActiveIndicator orangeGradient"></div>
-	</li>
+	</li>	
 	<li >
-		<a href="authentication.html">Authentication</a>
+		<a href="performance-single-node-vs-cluster.html">Single Node vs Cluster</a>
 		<div class="isActiveIndicator orangeGradient"></div>
-	</li>
-	<li >
-		<a href="permissioning.html">Permissioning</a>
-		<div class="isActiveIndicator orangeGradient"></div>
-	</li>
-
-	<li class="head">Server</li>
-	<li >
-		<a href="connectors-and-deployment.html">Connectors and Deployment</a>
-		<div class="isActiveIndicator orangeGradient"></div>
-	</li>
-	<li >
-		<a href="data-provider.html">Building a data-provider</a>
-		<div class="isActiveIndicator orangeGradient"></div>
-	</li>
-	<li >
-		<a href="searching-and-querying.html">Searching & Querying</a>
-		<div class="isActiveIndicator orangeGradient"></div>
-	</li>
-	<li >
-		<a href="transforming-data.html">Transforming Data</a>
-		<div class="isActiveIndicator orangeGradient"></div>
-	</li>
-	<li >
-		<a href="writing-storage-cache-connector.html">Writing storage and cache connectors</a>
-		<div class="isActiveIndicator orangeGradient"></div>
-	</li>
-	<li >
-		<a href="writing-messaging-connector.html">Writing a messaging connector</a>
-		<div class="isActiveIndicator orangeGradient"></div>
-	</li>
-
-	<li class="head">Client</li>
-	<li >
-		<a href="node-js-client.html">Using the client in NodeJS</a>
-		<div class="isActiveIndicator orangeGradient"></div>
-	</li>
-
-	<li >
-		<a href="records.html">Records</a>
-		<div class="isActiveIndicator orangeGradient"></div>
-	</li>
-
-	<li >
-		<a href="lists.html">Lists</a>
-		<div class="isActiveIndicator orangeGradient"></div>
-	</li>
-
-	<li >
-		<a href="events-and-rpcs.html">Events & RPCs</a>
-		<div class="isActiveIndicator orangeGradient"></div>
-	</li>
-
-	<li >
-		<a href="simple-app-using-ko.html">Simple App using Knockout</a>
-		<div class="isActiveIndicator orangeGradient"></div>
-	</li>
-
-	<li >
-		<a href="simple-app-using-react.html">Simple App using React</a>
-		<div class="isActiveIndicator orangeGradient"></div>
-	</li>
-
-	<li >
-		<a href="simple-app-using-angular.html">Simple App using Angular</a>
-		<div class="isActiveIndicator orangeGradient"></div>
-	</li>
-
-	<li class="head">Internals</li>
-	<li >
-		<a href="message-structure.html">Message Structure</a>
-		<div class="isActiveIndicator orangeGradient"></div>
-	</li>
+	</li>	
 </ul>
 
 			<div id="content">
-				<script type="text/javascript">
-	document.location.href = 'getting-started.html'
-</script>
+				
 
 			</div>
 		</div>

--- a/htdocs/info/index.html
+++ b/htdocs/info/index.html
@@ -6,7 +6,7 @@
 
 	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 	<meta name="keywords" content="deepstream, deepstream.io, streaming, realtime, server, socket" />
-	<meta name="description" content="deepstream.io - a scalable server for realtime web apps" />
+	<meta name="description" content="a node.js realtime server" />
 	<meta name="author" content="Wolfram Hempel" />
 	<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
 	<link rel="icon" href="/favicon.ico" type="image/x-icon">

--- a/htdocs/info/other-release-notes.html
+++ b/htdocs/info/other-release-notes.html
@@ -2,11 +2,11 @@
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<title>deepstream.io | A Scalable Server for Realtime Web Apps</title>
+	<title>deepstream.io | Other release notes</title>
 
 	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 	<meta name="keywords" content="deepstream, deepstream.io, streaming, realtime, server, socket" />
-	<meta name="description" content="a node.js realtime server" />
+	<meta name="description" content="Track releases for storage-, cache-, or message connector" />
 	<meta name="author" content="Wolfram Hempel" />
 	<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
 	<link rel="icon" href="/favicon.ico" type="image/x-icon">
@@ -25,7 +25,7 @@
 	<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
 
 </head>
-<body class="category_tutorials">
+<body class="category_info">
 
 	<div id="outerWrapper">
 		<div class="topSection">
@@ -36,101 +36,27 @@
 				<ul>
 					<li ><a href="..">Home</a></li>
 					<li ><a href="../download/">Downloads</a></li>
-					<li class="active"><a href="../tutorials/getting-started.html">Tutorials</a></li>
+					<li ><a href="../tutorials/getting-started.html">Tutorials</a></li>
 					<li ><a href="../docs/deepstream.html">Documentation</a></li>
-					<li ><a href="../info/">Info</a></li>
+					<li class="active"><a href="../info/">Info</a></li>
 				</ul>
 			</div>
 		</div>
 		<div id="wrapper" class="main">
 			<ul id="subnav">
-	<li class="head first">General</li>
+	<li class="head first">Performance</li>
 	<li >
-		<a href="getting-started.html">Getting started</a>
+		<a href="performance-overview.html">Overview</a>
 		<div class="isActiveIndicator orangeGradient"></div>
-	</li>
+	</li>	
 	<li >
-		<a href="authentication.html">Authentication</a>
+		<a href="performance-single-node-vs-cluster.html">Single Node vs Cluster</a>
 		<div class="isActiveIndicator orangeGradient"></div>
-	</li>
-	<li >
-		<a href="permissioning.html">Permissioning</a>
-		<div class="isActiveIndicator orangeGradient"></div>
-	</li>
-
-	<li class="head">Server</li>
-	<li >
-		<a href="connectors-and-deployment.html">Connectors and Deployment</a>
-		<div class="isActiveIndicator orangeGradient"></div>
-	</li>
-	<li >
-		<a href="data-provider.html">Building a data-provider</a>
-		<div class="isActiveIndicator orangeGradient"></div>
-	</li>
-	<li >
-		<a href="searching-and-querying.html">Searching & Querying</a>
-		<div class="isActiveIndicator orangeGradient"></div>
-	</li>
-	<li >
-		<a href="transforming-data.html">Transforming Data</a>
-		<div class="isActiveIndicator orangeGradient"></div>
-	</li>
-	<li >
-		<a href="writing-storage-cache-connector.html">Writing storage and cache connectors</a>
-		<div class="isActiveIndicator orangeGradient"></div>
-	</li>
-	<li >
-		<a href="writing-messaging-connector.html">Writing a messaging connector</a>
-		<div class="isActiveIndicator orangeGradient"></div>
-	</li>
-
-	<li class="head">Client</li>
-	<li >
-		<a href="node-js-client.html">Using the client in NodeJS</a>
-		<div class="isActiveIndicator orangeGradient"></div>
-	</li>
-
-	<li >
-		<a href="records.html">Records</a>
-		<div class="isActiveIndicator orangeGradient"></div>
-	</li>
-
-	<li >
-		<a href="lists.html">Lists</a>
-		<div class="isActiveIndicator orangeGradient"></div>
-	</li>
-
-	<li >
-		<a href="events-and-rpcs.html">Events & RPCs</a>
-		<div class="isActiveIndicator orangeGradient"></div>
-	</li>
-
-	<li >
-		<a href="simple-app-using-ko.html">Simple App using Knockout</a>
-		<div class="isActiveIndicator orangeGradient"></div>
-	</li>
-
-	<li >
-		<a href="simple-app-using-react.html">Simple App using React</a>
-		<div class="isActiveIndicator orangeGradient"></div>
-	</li>
-
-	<li >
-		<a href="simple-app-using-angular.html">Simple App using Angular</a>
-		<div class="isActiveIndicator orangeGradient"></div>
-	</li>
-
-	<li class="head">Internals</li>
-	<li >
-		<a href="message-structure.html">Message Structure</a>
-		<div class="isActiveIndicator orangeGradient"></div>
-	</li>
+	</li>	
 </ul>
 
 			<div id="content">
-				<script type="text/javascript">
-	document.location.href = 'getting-started.html'
-</script>
+				
 
 			</div>
 		</div>

--- a/htdocs/info/performance-overview.html
+++ b/htdocs/info/performance-overview.html
@@ -2,11 +2,11 @@
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<title>deepstream.io | A Scalable Server for Realtime Web Apps</title>
+	<title>deepstream.io | Performance testing overview</title>
 
 	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 	<meta name="keywords" content="deepstream, deepstream.io, streaming, realtime, server, socket" />
-	<meta name="description" content="deepstream.io - a scalable server for realtime web apps" />
+	<meta name="description" content="An introduction to how we conduct perfomance testing for deepstream" />
 	<meta name="author" content="Wolfram Hempel" />
 	<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
 	<link rel="icon" href="/favicon.ico" type="image/x-icon">

--- a/htdocs/info/performance-single-node-vs-cluster.html
+++ b/htdocs/info/performance-single-node-vs-cluster.html
@@ -2,11 +2,11 @@
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<title>deepstream.io | A Scalable Server for Realtime Web Apps</title>
+	<title>deepstream.io | Performance: Single Node vs Three Instance Cluster</title>
 
 	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 	<meta name="keywords" content="deepstream, deepstream.io, streaming, realtime, server, socket" />
-	<meta name="description" content="deepstream.io - a scalable server for realtime web apps" />
+	<meta name="description" content="A summary of our performance tests for deepstrean as a single node vs a cluster" />
 	<meta name="author" content="Wolfram Hempel" />
 	<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
 	<link rel="icon" href="/favicon.ico" type="image/x-icon">

--- a/htdocs/info/server-release-notes.html
+++ b/htdocs/info/server-release-notes.html
@@ -2,11 +2,11 @@
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<title>deepstream.io | A Scalable Server for Realtime Web Apps</title>
+	<title>deepstream.io | Deepstream Server release notes</title>
 
 	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 	<meta name="keywords" content="deepstream, deepstream.io, streaming, realtime, server, socket" />
-	<meta name="description" content="a node.js realtime server" />
+	<meta name="description" content="Keep track of the changes to the deepstream server" />
 	<meta name="author" content="Wolfram Hempel" />
 	<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
 	<link rel="icon" href="/favicon.ico" type="image/x-icon">
@@ -25,7 +25,7 @@
 	<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
 
 </head>
-<body class="category_tutorials">
+<body class="category_info">
 
 	<div id="outerWrapper">
 		<div class="topSection">
@@ -36,101 +36,34 @@
 				<ul>
 					<li ><a href="..">Home</a></li>
 					<li ><a href="../download/">Downloads</a></li>
-					<li class="active"><a href="../tutorials/getting-started.html">Tutorials</a></li>
+					<li ><a href="../tutorials/getting-started.html">Tutorials</a></li>
 					<li ><a href="../docs/deepstream.html">Documentation</a></li>
-					<li ><a href="../info/">Info</a></li>
+					<li class="active"><a href="../info/">Info</a></li>
 				</ul>
 			</div>
 		</div>
 		<div id="wrapper" class="main">
 			<ul id="subnav">
-	<li class="head first">General</li>
+	<li class="head first">Performance</li>
 	<li >
-		<a href="getting-started.html">Getting started</a>
+		<a href="performance-overview.html">Overview</a>
 		<div class="isActiveIndicator orangeGradient"></div>
-	</li>
+	</li>	
 	<li >
-		<a href="authentication.html">Authentication</a>
+		<a href="performance-single-node-vs-cluster.html">Single Node vs Cluster</a>
 		<div class="isActiveIndicator orangeGradient"></div>
-	</li>
-	<li >
-		<a href="permissioning.html">Permissioning</a>
-		<div class="isActiveIndicator orangeGradient"></div>
-	</li>
-
-	<li class="head">Server</li>
-	<li >
-		<a href="connectors-and-deployment.html">Connectors and Deployment</a>
-		<div class="isActiveIndicator orangeGradient"></div>
-	</li>
-	<li >
-		<a href="data-provider.html">Building a data-provider</a>
-		<div class="isActiveIndicator orangeGradient"></div>
-	</li>
-	<li >
-		<a href="searching-and-querying.html">Searching & Querying</a>
-		<div class="isActiveIndicator orangeGradient"></div>
-	</li>
-	<li >
-		<a href="transforming-data.html">Transforming Data</a>
-		<div class="isActiveIndicator orangeGradient"></div>
-	</li>
-	<li >
-		<a href="writing-storage-cache-connector.html">Writing storage and cache connectors</a>
-		<div class="isActiveIndicator orangeGradient"></div>
-	</li>
-	<li >
-		<a href="writing-messaging-connector.html">Writing a messaging connector</a>
-		<div class="isActiveIndicator orangeGradient"></div>
-	</li>
-
-	<li class="head">Client</li>
-	<li >
-		<a href="node-js-client.html">Using the client in NodeJS</a>
-		<div class="isActiveIndicator orangeGradient"></div>
-	</li>
-
-	<li >
-		<a href="records.html">Records</a>
-		<div class="isActiveIndicator orangeGradient"></div>
-	</li>
-
-	<li >
-		<a href="lists.html">Lists</a>
-		<div class="isActiveIndicator orangeGradient"></div>
-	</li>
-
-	<li >
-		<a href="events-and-rpcs.html">Events & RPCs</a>
-		<div class="isActiveIndicator orangeGradient"></div>
-	</li>
-
-	<li >
-		<a href="simple-app-using-ko.html">Simple App using Knockout</a>
-		<div class="isActiveIndicator orangeGradient"></div>
-	</li>
-
-	<li >
-		<a href="simple-app-using-react.html">Simple App using React</a>
-		<div class="isActiveIndicator orangeGradient"></div>
-	</li>
-
-	<li >
-		<a href="simple-app-using-angular.html">Simple App using Angular</a>
-		<div class="isActiveIndicator orangeGradient"></div>
-	</li>
-
-	<li class="head">Internals</li>
-	<li >
-		<a href="message-structure.html">Message Structure</a>
-		<div class="isActiveIndicator orangeGradient"></div>
-	</li>
+	</li>	
 </ul>
 
 			<div id="content">
-				<script type="text/javascript">
-	document.location.href = 'getting-started.html'
-</script>
+				<p>Deepstream.io server releases</p><ul>
+<li><strong>0.2.10</strong> <em>(19.4.2015)</em> Initial Public Release<ul>
+<li>Issue a</li>
+<li>Issue b</li>
+</ul>
+</li>
+</ul>
+
 
 			</div>
 		</div>

--- a/htdocs/tutorials/authentication.html
+++ b/htdocs/tutorials/authentication.html
@@ -2,11 +2,11 @@
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<title>deepstream.io | A Scalable Server for Realtime Web Apps</title>
+	<title>deepstream.io | Authentication tutorial</title>
 
 	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 	<meta name="keywords" content="deepstream, deepstream.io, streaming, realtime, server, socket" />
-	<meta name="description" content="deepstream.io - a scalable server for realtime web apps" />
+	<meta name="description" content="learn how to authenticate clients against deepstream servers" />
 	<meta name="author" content="Wolfram Hempel" />
 	<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
 	<link rel="icon" href="/favicon.ico" type="image/x-icon">

--- a/htdocs/tutorials/connectors-and-deployment.html
+++ b/htdocs/tutorials/connectors-and-deployment.html
@@ -2,11 +2,11 @@
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<title>deepstream.io | A Scalable Server for Realtime Web Apps</title>
+	<title>deepstream.io | Connectors and Deployment tutorial</title>
 
 	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 	<meta name="keywords" content="deepstream, deepstream.io, streaming, realtime, server, socket" />
-	<meta name="description" content="deepstream.io - a scalable server for realtime web apps" />
+	<meta name="description" content="learn how deepstream connects to caches, databases and messaging systems" />
 	<meta name="author" content="Wolfram Hempel" />
 	<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
 	<link rel="icon" href="/favicon.ico" type="image/x-icon">

--- a/htdocs/tutorials/data-provider.html
+++ b/htdocs/tutorials/data-provider.html
@@ -2,11 +2,11 @@
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<title>deepstream.io | A Scalable Server for Realtime Web Apps</title>
+	<title>deepstream.io | Data-Provider tutorial</title>
 
 	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 	<meta name="keywords" content="deepstream, deepstream.io, streaming, realtime, server, socket" />
-	<meta name="description" content="deepstream.io - a scalable server for realtime web apps" />
+	<meta name="description" content="learn how to build backend services that interact with deepstream" />
 	<meta name="author" content="Wolfram Hempel" />
 	<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
 	<link rel="icon" href="/favicon.ico" type="image/x-icon">
@@ -291,7 +291,6 @@ currencyPair<span class="token punctuation" >.</span><span class="token function
         </li>
       </ul>
 </div>
-
 
 			</div>
 		</div>

--- a/htdocs/tutorials/events-and-rpcs.html
+++ b/htdocs/tutorials/events-and-rpcs.html
@@ -2,11 +2,11 @@
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<title>deepstream.io | A Scalable Server for Realtime Web Apps</title>
+	<title>deepstream.io | Events and RPCs</title>
 
 	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 	<meta name="keywords" content="deepstream, deepstream.io, streaming, realtime, server, socket" />
-	<meta name="description" content="deepstream.io - a scalable server for realtime web apps" />
+	<meta name="description" content="a quick overview over deepstream&#x27;s event and rpc features" />
 	<meta name="author" content="Wolfram Hempel" />
 	<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
 	<link rel="icon" href="/favicon.ico" type="image/x-icon">

--- a/htdocs/tutorials/getting-started.html
+++ b/htdocs/tutorials/getting-started.html
@@ -2,11 +2,11 @@
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<title>deepstream.io | A Scalable Server for Realtime Web Apps</title>
+	<title>deepstream.io | Getting started</title>
 
 	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 	<meta name="keywords" content="deepstream, deepstream.io, streaming, realtime, server, socket" />
-	<meta name="description" content="deepstream.io - a scalable server for realtime web apps" />
+	<meta name="description" content="learn how to get up and running with deepstream" />
 	<meta name="author" content="Wolfram Hempel" />
 	<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
 	<link rel="icon" href="/favicon.ico" type="image/x-icon">

--- a/htdocs/tutorials/lists.html
+++ b/htdocs/tutorials/lists.html
@@ -2,11 +2,11 @@
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<title>deepstream.io | A Scalable Server for Realtime Web Apps</title>
+	<title>deepstream.io | Lists tutorial</title>
 
 	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 	<meta name="keywords" content="deepstream, deepstream.io, streaming, realtime, server, socket" />
-	<meta name="description" content="deepstream.io - a scalable server for realtime web apps" />
+	<meta name="description" content="learn how to use deepstream&#x27;s list feature to manage collections of records" />
 	<meta name="author" content="Wolfram Hempel" />
 	<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
 	<link rel="icon" href="/favicon.ico" type="image/x-icon">

--- a/htdocs/tutorials/message-structure.html
+++ b/htdocs/tutorials/message-structure.html
@@ -2,11 +2,11 @@
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<title>deepstream.io | A Scalable Server for Realtime Web Apps</title>
+	<title>deepstream.io | Message Structure</title>
 
 	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 	<meta name="keywords" content="deepstream, deepstream.io, streaming, realtime, server, socket" />
-	<meta name="description" content="deepstream.io - a scalable server for realtime web apps" />
+	<meta name="description" content="An overview over deepstreams internal message structure" />
 	<meta name="author" content="Wolfram Hempel" />
 	<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
 	<link rel="icon" href="/favicon.ico" type="image/x-icon">

--- a/htdocs/tutorials/node-js-client.html
+++ b/htdocs/tutorials/node-js-client.html
@@ -2,11 +2,11 @@
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<title>deepstream.io | A Scalable Server for Realtime Web Apps</title>
+	<title>deepstream.io | How to use the deepstream client in NodeJS</title>
 
 	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 	<meta name="keywords" content="deepstream, deepstream.io, streaming, realtime, server, socket" />
-	<meta name="description" content="deepstream.io - a scalable server for realtime web apps" />
+	<meta name="description" content="Learn how deepstream&#x27;s javascript client can be used in NodeJS" />
 	<meta name="author" content="Wolfram Hempel" />
 	<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
 	<link rel="icon" href="/favicon.ico" type="image/x-icon">

--- a/htdocs/tutorials/permissioning.html
+++ b/htdocs/tutorials/permissioning.html
@@ -2,11 +2,11 @@
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<title>deepstream.io | A Scalable Server for Realtime Web Apps</title>
+	<title>deepstream.io | Permissioning tutorial</title>
 
 	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 	<meta name="keywords" content="deepstream, deepstream.io, streaming, realtime, server, socket" />
-	<meta name="description" content="deepstream.io - a scalable server for realtime web apps" />
+	<meta name="description" content="Learn how to allow or deny individual actions within deepstream" />
 	<meta name="author" content="Wolfram Hempel" />
 	<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
 	<link rel="icon" href="/favicon.ico" type="image/x-icon">

--- a/htdocs/tutorials/records-events-rpcs.html
+++ b/htdocs/tutorials/records-events-rpcs.html
@@ -2,11 +2,11 @@
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<title>deepstream.io | A Scalable Server for Realtime Web Apps</title>
+	<title>deepstream.io | Records, Events and RPCs</title>
 
 	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 	<meta name="keywords" content="deepstream, deepstream.io, streaming, realtime, server, socket" />
-	<meta name="description" content="deepstream.io - a scalable server for realtime web apps" />
+	<meta name="description" content="a short overview over deepstream&#x27;s core concepts" />
 	<meta name="author" content="Wolfram Hempel" />
 	<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
 	<link rel="icon" href="/favicon.ico" type="image/x-icon">

--- a/htdocs/tutorials/records.html
+++ b/htdocs/tutorials/records.html
@@ -2,11 +2,11 @@
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<title>deepstream.io | A Scalable Server for Realtime Web Apps</title>
+	<title>deepstream.io | Records tutorial</title>
 
 	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 	<meta name="keywords" content="deepstream, deepstream.io, streaming, realtime, server, socket" />
-	<meta name="description" content="deepstream.io - a scalable server for realtime web apps" />
+	<meta name="description" content="learn about records, deepstream&#x27;s observable data structures" />
 	<meta name="author" content="Wolfram Hempel" />
 	<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
 	<link rel="icon" href="/favicon.ico" type="image/x-icon">

--- a/htdocs/tutorials/searching-and-querying.html
+++ b/htdocs/tutorials/searching-and-querying.html
@@ -2,11 +2,11 @@
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<title>deepstream.io | A Scalable Server for Realtime Web Apps</title>
+	<title>deepstream.io | Searching and Querying</title>
 
 	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 	<meta name="keywords" content="deepstream, deepstream.io, streaming, realtime, server, socket" />
-	<meta name="description" content="deepstream.io - a scalable server for realtime web apps" />
+	<meta name="description" content="Learn how to add search functionality to deepstream" />
 	<meta name="author" content="Wolfram Hempel" />
 	<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
 	<link rel="icon" href="/favicon.ico" type="image/x-icon">

--- a/htdocs/tutorials/simple-app-using-angular.html
+++ b/htdocs/tutorials/simple-app-using-angular.html
@@ -2,11 +2,11 @@
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<title>deepstream.io | A Scalable Server for Realtime Web Apps</title>
+	<title>deepstream.io | Simple app using AngularJS</title>
 
 	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 	<meta name="keywords" content="deepstream, deepstream.io, streaming, realtime, server, socket" />
-	<meta name="description" content="deepstream.io - a scalable server for realtime web apps" />
+	<meta name="description" content="Learn how to build a simple address manager using deepstream and AngularJS" />
 	<meta name="author" content="Wolfram Hempel" />
 	<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
 	<link rel="icon" href="/favicon.ico" type="image/x-icon">

--- a/htdocs/tutorials/simple-app-using-ko.html
+++ b/htdocs/tutorials/simple-app-using-ko.html
@@ -2,11 +2,11 @@
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<title>deepstream.io | A Scalable Server for Realtime Web Apps</title>
+	<title>deepstream.io | Simple app using KnockoutJs</title>
 
 	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 	<meta name="keywords" content="deepstream, deepstream.io, streaming, realtime, server, socket" />
-	<meta name="description" content="deepstream.io - a scalable server for realtime web apps" />
+	<meta name="description" content="Learn how to build a simple address manager using deepstream and KnockoutJs" />
 	<meta name="author" content="Wolfram Hempel" />
 	<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
 	<link rel="icon" href="/favicon.ico" type="image/x-icon">

--- a/htdocs/tutorials/simple-app-using-react.html
+++ b/htdocs/tutorials/simple-app-using-react.html
@@ -2,11 +2,11 @@
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<title>deepstream.io | A Scalable Server for Realtime Web Apps</title>
+	<title>deepstream.io | Simple app using React</title>
 
 	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 	<meta name="keywords" content="deepstream, deepstream.io, streaming, realtime, server, socket" />
-	<meta name="description" content="deepstream.io - a scalable server for realtime web apps" />
+	<meta name="description" content="Learn how to build a simple address manager using deepstream and Facebook&#x27;s ReactJS" />
 	<meta name="author" content="Wolfram Hempel" />
 	<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
 	<link rel="icon" href="/favicon.ico" type="image/x-icon">

--- a/htdocs/tutorials/transforming-data.html
+++ b/htdocs/tutorials/transforming-data.html
@@ -2,11 +2,11 @@
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<title>deepstream.io | A Scalable Server for Realtime Web Apps</title>
+	<title>deepstream.io | Transforming outgoing data</title>
 
 	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 	<meta name="keywords" content="deepstream, deepstream.io, streaming, realtime, server, socket" />
-	<meta name="description" content="deepstream.io - a scalable server for realtime web apps" />
+	<meta name="description" content="Learn how to use transform functions to manipulate data before it leaves the server" />
 	<meta name="author" content="Wolfram Hempel" />
 	<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
 	<link rel="icon" href="/favicon.ico" type="image/x-icon">

--- a/htdocs/tutorials/writing-messaging-connector.html
+++ b/htdocs/tutorials/writing-messaging-connector.html
@@ -2,11 +2,11 @@
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<title>deepstream.io | A Scalable Server for Realtime Web Apps</title>
+	<title>deepstream.io | Writing a message connector</title>
 
 	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 	<meta name="keywords" content="deepstream, deepstream.io, streaming, realtime, server, socket" />
-	<meta name="description" content="deepstream.io - a scalable server for realtime web apps" />
+	<meta name="description" content="Learn how to integrate deepstream with a messaging system of your choice" />
 	<meta name="author" content="Wolfram Hempel" />
 	<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
 	<link rel="icon" href="/favicon.ico" type="image/x-icon">

--- a/htdocs/tutorials/writing-storage-cache-connector.html
+++ b/htdocs/tutorials/writing-storage-cache-connector.html
@@ -2,11 +2,11 @@
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<title>deepstream.io | A Scalable Server for Realtime Web Apps</title>
+	<title>deepstream.io | Writing storage and cache connectors</title>
 
 	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 	<meta name="keywords" content="deepstream, deepstream.io, streaming, realtime, server, socket" />
-	<meta name="description" content="deepstream.io - a scalable server for realtime web apps" />
+	<meta name="description" content="Learn how to integrate deepstream with a cache or database of your choice" />
 	<meta name="author" content="Wolfram Hempel" />
 	<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
 	<link rel="icon" href="/favicon.ico" type="image/x-icon">
@@ -167,7 +167,6 @@ all data is lost when the process exists. Caches also usually don&#39;t offer su
           </li>
       </ul>
 </div>
-
 
 			</div>
 		</div>

--- a/index.hbs
+++ b/index.hbs
@@ -2,11 +2,11 @@
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<title>deepstream.io | A Scalable Server for Realtime Web Apps</title>
+	<title>deepstream.io | {{title}}</title>
 
 	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 	<meta name="keywords" content="deepstream, deepstream.io, streaming, realtime, server, socket" />
-	<meta name="description" content="deepstream.io - a scalable server for realtime web apps" />
+	<meta name="description" content="{{description}}" />
 	<meta name="author" content="Wolfram Hempel" />
 	<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
 	<link rel="icon" href="/favicon.ico" type="image/x-icon">

--- a/pages/docs/anonymous_record.md
+++ b/pages/docs/anonymous_record.md
@@ -1,3 +1,7 @@
+{
+	"title": "anonymous record documentation",
+	"description": "learn how to use anonymous records to switch context without having to renew bindings"
+}
 Anonymous Record
 ----------------------------------
 

--- a/pages/docs/client.event.md
+++ b/pages/docs/client.event.md
@@ -1,3 +1,7 @@
+{
+	"title": "event API documentation",
+	"description": "understand events, deepstream's many to many broadcasting mechanism"
+}
 Events
 -------------------------
 Events provide a simple way of sending messages betweem clients. Deepstream's event mechanism basically works like an EventEmitter that's distributed across clients.

--- a/pages/docs/client.md
+++ b/pages/docs/client.md
@@ -1,3 +1,7 @@
+{
+	"title": "javascript client API documentation",
+	"description": "the API docs for the deepstream javascript client"
+}
 deepstream( url, options )
 ------------------------------
 argument: url

--- a/pages/docs/client.record.md
+++ b/pages/docs/client.record.md
@@ -1,3 +1,7 @@
+{
+	"title": "Record API documentation",
+	"description": "the API docs for deepstream records"
+}
 client.record.getRecord( name )
 --------------------------------
 argument: name

--- a/pages/docs/client.rpc.md
+++ b/pages/docs/client.rpc.md
@@ -1,3 +1,7 @@
+{
+	"title": "RPC API documentation",
+	"description": "the API docs for Remote Procedure Calls, deepstream's request-response mechanism"
+}
 Remote Procedure Calls (RPCs)
 -----------------------------
 RPCs are deepstream's mechanism for request/response communication (think Ajax Request, but with load balancing). Deepstream clients can register as providers for RPCs using `provide`, e.g.

--- a/pages/docs/client_errors.md
+++ b/pages/docs/client_errors.md
@@ -1,3 +1,7 @@
+{
+	"title": "runtime error documentation",
+	"description": "the API docs for deepstream's runtime errors"
+}
 Errors
 ---------------------------------
 <table class="mini">

--- a/pages/docs/client_options.md
+++ b/pages/docs/client_options.md
@@ -1,3 +1,7 @@
+{
+	"title": "client options",
+	"description": "the options that the deepstream javascript client can be initialized with"
+}
 Client Options
 ---------------------------------
 

--- a/pages/docs/connection_states.md
+++ b/pages/docs/connection_states.md
@@ -1,3 +1,7 @@
+{
+	"title": "connection state documentation",
+	"description": "a list of all possible connection states"
+}
 Connection States
 -----------------------------
 <table class="mini">

--- a/pages/docs/constants.md
+++ b/pages/docs/constants.md
@@ -1,3 +1,7 @@
+{
+   "title": "constants documentation",
+   "description": "a list of all constants deepstream uses"
+}
 Constants
 ----------------------------------
 Constants are used throughout deepstream. They can be accessed from the outside via the server instance 

--- a/pages/docs/deepstream.md
+++ b/pages/docs/deepstream.md
@@ -1,3 +1,7 @@
+{
+	"title": "deepstream server documentation",
+	"description": "API docs for new Deepstream();"
+}
 Constructor
 ------------------------------
 The constructor takes no arguments.

--- a/pages/docs/event_emitter.md
+++ b/pages/docs/event_emitter.md
@@ -1,3 +1,7 @@
+{
+	"title": "EventEmitter documentation",
+	"description": "API docs for deepstream's event emitter"
+}
 EventEmitter
 -----------------------
 The deepstream-client uses [component-emitter](https://www.npmjs.com/package/component-emitter) as an event-emitter which in turn implements a subset of the [NodeJS EventEmitter API](https://nodejs.org/api/events.html).

--- a/pages/docs/list.md
+++ b/pages/docs/list.md
@@ -1,3 +1,7 @@
+{
+	"title": "List API documentation",
+	"description": "API docs for deepstream's list object, a manageable collection of record names"
+}
 List
 ---------------------------------
 Lists are arrays of record names. Similar to records, lists can be manipulated and observed. Lists are created and retrieved using `client.record.get( 'name' );`, e.g.

--- a/pages/docs/record.md
+++ b/pages/docs/record.md
@@ -1,3 +1,7 @@
+{
+	"title": "record API documentation",
+	"description": "the API docs for deepstream Records"
+}
 Record
 ----------------------------------
 Records are one of deepstream's core features. A Record is an arbitrary JSON data structure that can be created, retrieved, updated, deleted and listened to. Records are created and retrieved using

--- a/pages/docs/rpc_response.md
+++ b/pages/docs/rpc_response.md
@@ -1,3 +1,7 @@
+{
+	"title": "RPC response documentation",
+	"description": "API docs for deepstream's RPC response object"
+}
 RpcResponse
 -----------------------
 RpcResponse objects are passed to rpc `provide` callbacks. They allow to explicitely acknowledge, complete or reject requests 

--- a/pages/info/client-release-notes.md
+++ b/pages/info/client-release-notes.md
@@ -1,0 +1,4 @@
+{
+	"title": "Client release notes",
+	"description": "See what was released in every version of the deepstream javascript client"
+}

--- a/pages/info/other-release-notes.md
+++ b/pages/info/other-release-notes.md
@@ -1,0 +1,4 @@
+{
+	"title": "Other release notes",
+	"description": "Track releases for storage-, cache-, or message connector"
+}

--- a/pages/info/performance-overview.md
+++ b/pages/info/performance-overview.md
@@ -1,3 +1,7 @@
+{
+	"title": "Performance testing overview",
+	"description": "An introduction to how we conduct perfomance testing for deepstream"
+}
 Performance Overview
 ============================
 

--- a/pages/info/performance-single-node-vs-cluster.md
+++ b/pages/info/performance-single-node-vs-cluster.md
@@ -1,3 +1,7 @@
+{
+	"title": "Performance: Single Node vs Three Instance Cluster",
+	"description": "A summary of our performance tests for deepstrean as a single node vs a cluster"
+}
 Performance: Single Node vs Three Instance Cluster
 ======================================
 This test aims to verify horizontal scalability by establishing message latency and cpu consumption under high traffic for a single deepstream node in comparison to a cluster of three nodes.

--- a/pages/info/server-release-notes.md
+++ b/pages/info/server-release-notes.md
@@ -1,0 +1,10 @@
+{
+	"title": "Deepstream Server release notes",
+	"description": "Keep track of the changes to the deepstream server"
+}
+Deepstream.io server releases
+
+* **0.2.10** _(19.4.2015)_ Initial Public Release
+	- Issue a
+	- Issue b  
+

--- a/pages/tutorials/authentication.md
+++ b/pages/tutorials/authentication.md
@@ -1,3 +1,7 @@
+{
+	"title": "Authentication tutorial",
+	"description": "learn how to authenticate clients against deepstream servers"
+}
 Authentication
 ======================================
 Deepstream's security and permission model is very powerful, yet really simple. In fact,

--- a/pages/tutorials/connectors-and-deployment.md
+++ b/pages/tutorials/connectors-and-deployment.md
@@ -1,3 +1,7 @@
+{
+	"title": "Connectors and Deployment tutorial",
+	"description": "learn how deepstream connects to caches, databases and messaging systems"
+}
 Connectors and Deployment
 ===============================
 

--- a/pages/tutorials/data-provider.md
+++ b/pages/tutorials/data-provider.md
@@ -1,3 +1,7 @@
+{
+  "title": "Data-Provider tutorial",
+  "description": "learn how to build backend services that interact with deepstream"
+}
 Building a Data-Provider
 ===========================================
 

--- a/pages/tutorials/events-and-rpcs.md
+++ b/pages/tutorials/events-and-rpcs.md
@@ -1,3 +1,7 @@
+{
+	"title": "Events and RPCs",
+	"description": "a quick overview over deepstream's event and rpc features"
+}
 Events & RPCs
 ====================================
 In addition to records, deepstream provides means of messaging and request-response communication: events and rpcs.

--- a/pages/tutorials/getting-started.md
+++ b/pages/tutorials/getting-started.md
@@ -1,3 +1,7 @@
+{
+	"title": "Getting started",
+	"description": "learn how to get up and running with deepstream"
+}
 Getting started
 ====================================
 Learn how to 

--- a/pages/tutorials/lists.md
+++ b/pages/tutorials/lists.md
@@ -1,3 +1,7 @@
+{
+	"title": "Lists tutorial",
+	"description": "learn how to use deepstream's list feature to manage collections of records"
+}
 Lists
 ==============================
 [Lists](../docs/list.html) provide a way to manage a group of [Records](../docs/record.html). A list is an array of record names

--- a/pages/tutorials/message-structure.md
+++ b/pages/tutorials/message-structure.md
@@ -1,3 +1,7 @@
+{
+	"title": "Message Structure",
+	"description": "An overview over deepstreams internal message structure"
+}
 Message Structure
 ========================================
 Deepstream messages are transmitted using a proprietary, minimal, string-based protocol. Every message follows the same structure:

--- a/pages/tutorials/node-js-client.md
+++ b/pages/tutorials/node-js-client.md
@@ -1,3 +1,7 @@
+{
+	"title": "How to use the deepstream client in NodeJS",
+	"description": "Learn how deepstream's javascript client can be used in NodeJS"
+}
 Using the deepstream client in NodeJs
 ==============================================
 <img class="center" src="../assets/images/nodejs.png" alt="Node Js logo" />

--- a/pages/tutorials/permissioning.md
+++ b/pages/tutorials/permissioning.md
@@ -1,3 +1,7 @@
+{
+	"title": "Permissioning tutorial",
+	"description": "Learn how to allow or deny individual actions within deepstream"
+}
 Permissioning
 =========================
 Deepstream allows for every operation (creating or reading records, sending events, making RPCs etc.) to be permissioned individually for every user. This happens in the permissionHandler's `canPerformAction()` method. Every message needs to pass through here before it is processed.

--- a/pages/tutorials/records-events-rpcs.md
+++ b/pages/tutorials/records-events-rpcs.md
@@ -1,3 +1,7 @@
+{
+	"title": "Records, Events and RPCs",
+	"description": "a short overview over deepstream's core concepts"
+}
 Records, Events & RPCs
 ==============================
 Deepstream provides three core concepts: Records, Events and RPCs. Records are arbitrary JSON structures that can be manipulated and subscribed to, Events work like a normal event-emitter, but distributed across connected clients and RPCs(Remote Procedure Calls) allow for request-response communication, comparable to http requests.

--- a/pages/tutorials/records.md
+++ b/pages/tutorials/records.md
@@ -1,3 +1,7 @@
+{
+	"title": "Records tutorial",
+	"description": "learn about records, deepstream's observable data structures"
+}
 Records
 ==============================
 [Records](docs/record.html) are arbitrary JSON structures that can be manipulated and subscribed to. Every change to a record is synced accross all subscribed clients

--- a/pages/tutorials/searching-and-querying.md
+++ b/pages/tutorials/searching-and-querying.md
@@ -1,3 +1,7 @@
+{
+	"title": "Searching and Querying",
+	"description": "Learn how to add search functionality to deepstream"
+}
 Searching & Querying
 ====================================
 

--- a/pages/tutorials/simple-app-using-angular.md
+++ b/pages/tutorials/simple-app-using-angular.md
@@ -1,3 +1,7 @@
+{
+	"title": "Simple app using AngularJS",
+	"description": "Learn how to build a simple address manager using deepstream and AngularJS"
+}
 Building a simple app with deepstream and angular
 =====================================================
 

--- a/pages/tutorials/simple-app-using-ko.md
+++ b/pages/tutorials/simple-app-using-ko.md
@@ -1,3 +1,7 @@
+{
+	"title": "Simple app using KnockoutJs",
+	"description": "Learn how to build a simple address manager using deepstream and KnockoutJs"
+}
 Building a simple app with deepstream and knockout js
 =====================================================
 [KnockoutJs](http://knockoutjs.com/) works well with deepstream. Its two way bindings, atomic updates and overall speed make it a great fit for realtime applications. So well in fact, that we developed a tool that makes using it even easier.

--- a/pages/tutorials/simple-app-using-react.md
+++ b/pages/tutorials/simple-app-using-react.md
@@ -1,3 +1,7 @@
+{
+	"title": "Simple app using React",
+	"description": "Learn how to build a simple address manager using deepstream and Facebook's ReactJS"
+}
 Building a simple app with deepstream and react
 =====================================================
 

--- a/pages/tutorials/transforming-data.md
+++ b/pages/tutorials/transforming-data.md
@@ -1,3 +1,7 @@
+{
+	"title": "Transforming outgoing data",
+	"description": "Learn how to use transform functions to manipulate data before it leaves the server"
+}
 Transforming outgoing data
 ======================================
 Deepstream allows to manipulate data before it leaves the server. This can be useful for a number of usecases 

--- a/pages/tutorials/writing-messaging-connector.md
+++ b/pages/tutorials/writing-messaging-connector.md
@@ -1,3 +1,7 @@
+{
+	"title": "Writing a message connector",
+	"description": "Learn how to integrate deepstream with a messaging system of your choice"
+}
 Writing a message connector
 =====================================
 Deepstream nodes can work together in clusters – which requires them to communicate with each other. This can happen directly [via TCP]() or  through a messaging system, e.g. an AMQP broker, Apache Kafka or Redis’ pub sub mechanism.

--- a/pages/tutorials/writing-storage-cache-connector.md
+++ b/pages/tutorials/writing-storage-cache-connector.md
@@ -1,3 +1,7 @@
+{
+	"title": "Writing storage and cache connectors",
+	"description": "Learn how to integrate deepstream with a cache or database of your choice"
+}
 Writing storage and cache connectors
 ========================================
 


### PR DESCRIPTION
Each markdown file now has to start with a JSON meta-information block, e.g.

```
{
	"title": "Events and RPCs",
	"description": "a quick overview over deepstream's event and rpc features"
}
Events & RPCs
```